### PR TITLE
Show avatars _only_ if enabled

### DIFF
--- a/app/Hooks/Handlers/CommentsHandler.php
+++ b/app/Hooks/Handlers/CommentsHandler.php
@@ -273,16 +273,17 @@ class CommentsHandler
     {
         ob_start();
 
-        $avatar = get_avatar($comment, 64);
         $comment_author = get_comment_author($comment);
         ?>
         <div id="comment-<?php echo (int)$comment->comment_ID; ?>" class="flc_comment fls_new_comment">
             <article class="flc_body">
+                <?php if ( get_option('show_avatars') ): ?>
                 <div class="flc_avatar">
                     <div class="flc_comment_author">
-                        <?php echo wp_kses_post($avatar); ?>
+                        <?php echo wp_kses_post( get_avatar( $comment, 64 ) ); ?>
                     </div>
                 </div>
+                <?php endif; ?>
                 <div class="flc_comment__details">
                     <div class="crayons-card">
                         <div class="comment__header">

--- a/app/Services/FluentWalkerComment.php
+++ b/app/Services/FluentWalkerComment.php
@@ -21,17 +21,18 @@ class FluentWalkerComment extends \Walker_Comment {
      * @param array      $args    An array of arguments.
      */
     protected function html5_comment( $comment, $depth, $args ) {
-        $avatar             = get_avatar( $comment, $args['avatar_size'] );
         $comment_author     = get_comment_author( $comment );
         $args['depth'] = $depth;
         ?>
         <div id="comment-<?php comment_ID(); ?>" class="flc_comment">
             <article class="flc_body">
+                <?php if ( get_option('show_avatars') ): ?>
                 <div class="flc_avatar">
                     <div class="flc_comment_author">
-                        <?php echo wp_kses_post( $avatar ); ?>
+                        <?php echo wp_kses_post( get_avatar( $comment, $args['avatar_size'] ) ); ?>
                     </div>
                 </div>
+                <?php endif; ?>
                 <div class="flc_comment__details">
                     <div class="crayons-card">
                         <div class="comment__header">

--- a/app/Views/comment_form.php
+++ b/app/Views/comment_form.php
@@ -1,9 +1,12 @@
 <?php defined('ABSPATH') or die;
+$showAvatars = get_option('show_avatars');
 $userAvatar = 'https://secure.gravatar.com/avatar/?s=96&d=mm&r=g';
 $currentUser = false;
 if (get_current_user_id()) {
     $currentUser = get_user_by('ID', get_current_user_id());
-    $userAvatar = get_avatar_url($currentUser->user_email);
+    if ($showAvatars) {
+        $userAvatar = get_avatar_url($currentUser->user_email);
+    }
 }
 global $post;
 
@@ -19,11 +22,13 @@ $commentSign = (new \FluentComments\App\Hooks\Handlers\CommentsHandler)->encrypt
 <div class="flc_comment_respond" id="respond">
     <div class="flc_respond">
         <div class="flc_comment_wrap">
+            <?php if ( $showAvatars ): ?>
             <div class="flc_author_placeholder">
                 <div class="flc_comment_author">
                     <img src="<?php echo esc_url($userAvatar); ?>"/>
                 </div>
             </div>
+            <?php endif; ?>
             <div class="flc_comment_form">
                 <form id="flc_comment_form" method="POST">
                     <input type="hidden" name="comment_post_ID" value="<?php echo (int)$post->ID; ?>"/>


### PR DESCRIPTION
# change

This PR skips the output of avatar HTML if the site has avatars disabled. In 2 spots `get_avatar()` is inlined so it doesn't run when it doesn't need to, because `$avatar` is only used once.

# motivation

I have avatars disabled on all sites because all core avatar features use Gravatar, which I refuse to use. In the current version, even with avatars disabled, FC will load one or more remote Gravatar images on the frontend.